### PR TITLE
fix: TypeError: unsupported operand type(s) for *: 'DotMap' and 'float' (issue#62)

### DIFF
--- a/src/processors/CropOnMarkers.py
+++ b/src/processors/CropOnMarkers.py
@@ -215,7 +215,7 @@ class CropOnMarkers(ImagePreprocessor):
             MainOperations.show(
                 "Warped: " + args["current_file"].name,
                 ImageUtils.resize_util(
-                    h_stack, int(config.display_width * 1.6)),
+                    h_stack, int(config.dimensions.display_width * 1.6)),
                 0,
                 0,
                 [0, 0],


### PR DESCRIPTION
**fix** : resolved `TypeError: unsupported operand type(s) for *: 'DotMap' and 'float'`  by changing Image resize code 
from `int(config.display_width * 1.6))` to `int(config.dimensions.display_width * 1.6))`  in `CropOnMarkers.py`.

**ref** : issue #62 