### PR TITLE
[Bugfix] Resized and repositioned text over boxes to avoid crowding

### DIFF
--- a/src/utils/imgutils.py
+++ b/src/utils/imgutils.py
@@ -197,9 +197,9 @@ def draw_template_layout(img, template, shifted=True, draw_qvals=False, border=-
             cv2.putText(
                 final_align,
                 "%s" % (q_block.key),
-                (int(s[0] + d[0] - text_in_px[0][0]), int(s[1] - text_in_px[0][1])),
+                (int(s[0] + d[0] - text_in_px[0][0]), int(s[1] - text_in_px[0][1]) + 7), # random offset of 7 by hit and trial
                 cv2.FONT_HERSHEY_SIMPLEX,
-                constants.TEXT_SIZE,
+                constants.TEXT_SIZE * 0.7, # reduce text size
                 constants.CLR_BLACK,
                 4,
             )


### PR DESCRIPTION
Overview: Sort of fixes the issue opened in #97 .

Fix: Reduced text size and alignment to fit all text without crowding.

Before:
![before](https://user-images.githubusercontent.com/74849707/212540422-dd22e038-246d-4056-88aa-6cb593f1faec.jpg)


After:
![after](https://user-images.githubusercontent.com/74849707/212540363-c25b3580-fbbe-4dd9-bb70-700c5dc2f0e2.jpg)

