### PR TITLE
Fixed issue where OMR input images are processed twice in Windows env…

### DIFF
--- a/src/entry.py
+++ b/src/entry.py
@@ -64,7 +64,7 @@ def process_dir(
     paths = Paths(output_dir)
 
     # look for images in current dir to process
-    exts = ("*.png", "*.jpg", "*.jpeg", "*.PNG", "*.JPG", "*.JPEG")
+    exts = ("*.[pP][nN][gG]", "*.[jJ][pP][gG]", "*.[jJ][pP][eE][gG]")
     omr_files = sorted([f for ext in exts for f in curr_dir.glob(ext)])
 
     # Exclude images (take union over all pre_processors)


### PR DESCRIPTION
This fixes the bug in #130 where images process twice due to Windows being case-insensitive. 

#131 makes a change that appears to be valid but project maintainer suggested a simpler approach (as implemented). 