### PR TITLE
Added option to export explanation csv for all files

### DIFF
--- a/src/algorithm/evaluation/config.py
+++ b/src/algorithm/evaluation/config.py
@@ -458,6 +458,7 @@ class EvaluationConfigForSet:
             self.draw_question_verdicts,
             self.draw_score,
             self.should_explain_scoring,
+            self.should_export_csv,
         ) = map(
             outputs_configuration.get,
             [
@@ -466,6 +467,7 @@ class EvaluationConfigForSet:
                 "draw_question_verdicts",
                 "draw_score",
                 "should_explain_scoring",
+                "should_export_csv",
             ],
         )
         if self.draw_question_verdicts["enabled"]:
@@ -995,6 +997,7 @@ class EvaluationConfigForSet:
             ]
             self.explanation_table.add_row(*row)
 
+
     @staticmethod
     def get_schema_verdict(answer_type, question_verdict, delta=None):
         # Note: Negative custom weights should be considered as incorrect schema verdict(special case)
@@ -1013,6 +1016,12 @@ class EvaluationConfigForSet:
 
     def get_should_explain_scoring(self):
         return self.should_explain_scoring
+
+    def get_should_export_csv(self):
+        return self.should_export_csv
+
+    def get_explanation_table(self):
+        return self.explanation_table
 
     def get_formatted_answers_summary(self, answers_summary_format_string=None):
         if answers_summary_format_string is None:

--- a/src/algorithm/template/template.py
+++ b/src/algorithm/template/template.py
@@ -122,6 +122,9 @@ class Template:
     def get_errors_dir(self):
         return self.directory_handler.path_utils.errors_dir
 
+    def get_eval_dir(self):
+        return self.directory_handler.path_utils.eval_dir
+
     def read_omr_response(self, input_gray_image, colored_image, file_path):
         # Convert posix path to string
         file_path = str(file_path)

--- a/src/entry.py
+++ b/src/entry.py
@@ -5,6 +5,7 @@ from time import time
 
 import pandas as pd
 from rich.table import Table
+from rich_tools import table_to_df
 
 from src.algorithm.evaluation.config import EvaluationConfig
 from src.algorithm.evaluation.evaluation import evaluate_concatenated_response
@@ -326,8 +327,20 @@ def process_directory_files(
             logger.info(
                 f"(/{files_counter}) Graded with score: {round(score, 2)}\t {default_answers_summary} \t file: '{file_id}'"
             )
+            if evaluation_config_for_response.get_should_export_csv():
+                explanation_table = evaluation_config_for_response.get_explanation_table()
+                explanation_table = table_to_df(explanation_table)
+                explanation_table.to_csv(
+                    template.get_eval_dir().joinpath(file_name + ".csv"),
+                    quoting=QUOTE_NONNUMERIC,
+                    index=False,
+                )
+
         else:
             logger.info(f"(/{files_counter}) Processed file: '{file_id}'")
+
+
+
 
         # TODO: move this logic inside the class
         save_marked_dir = template.get_save_marked_dir()

--- a/src/schemas/evaluation_schema.py
+++ b/src/schemas/evaluation_schema.py
@@ -220,6 +220,10 @@ common_evaluation_schema_properties = {
                 "description": "Whether to print the table explaining question-wise verdicts",
                 "type": "boolean",
             },
+            "should_export_csv": {
+                "description": "Whether to export the explanation of evaluation results as a CSV file",
+                "type": "boolean",
+            },
             "draw_score": {
                 "description": "The configuration for drawing the final score",
                 "type": "object",

--- a/src/utils/file.py
+++ b/src/utils/file.py
@@ -62,6 +62,7 @@ class PathUtils:
         self.manual_dir = output_dir.joinpath("Manual")
         self.errors_dir = self.manual_dir.joinpath("ErrorFiles")
         self.multi_marked_dir = self.manual_dir.joinpath("MultiMarkedFiles")
+        self.eval_dir = output_dir.joinpath("Evaluations")
         self.debug_dir = output_dir.joinpath("Debug")
 
     def create_output_directories(self):
@@ -96,6 +97,7 @@ class PathUtils:
         for save_output_dir in [
             self.results_dir,
             self.image_metrics_dir,
+            self.eval_dir,
         ]:
             if not os.path.exists(save_output_dir):
                 logger.info(f"Created : {save_output_dir}")


### PR DESCRIPTION
Added a should_export_csv flag in evaluation_schema, if this value is set to true, explanation_table is exported to csv and stored in Evaluations directory