### PR TITLE
Fix reporting of whether markers are being used

### DIFF
--- a/src/entry.py
+++ b/src/entry.py
@@ -52,9 +52,10 @@ def print_config_summary(
     table.add_row("Directory Path", f"{curr_dir}")
     table.add_row("Count of Images", f"{len(omr_files)}")
     table.add_row("Set Layout Mode ", "ON" if args["setLayout"] else "OFF")
+    pre_processor_names = [pp.__class__.__name__ for pp in template.pre_processors]
     table.add_row(
         "Markers Detection",
-        "ON" if "CropOnMarkers" in template.pre_processors else "OFF",
+        "ON" if "CropOnMarkers" in pre_processor_names else "OFF",
     )
     table.add_row("Auto Alignment", f"{tuning_config.alignment_params.auto_align}")
     table.add_row("Detected Template Path", f"{template}")
@@ -65,7 +66,7 @@ def print_config_summary(
 
     table.add_row(
         "Detected pre-processors",
-        f"{[pp.__class__.__name__ for pp in template.pre_processors]}",
+        ", ".join(pre_processor_names),
     )
     console.print(table, justify="center")
 


### PR DESCRIPTION
As `template.pre_processors` contains objects, the test `"CropOnMarkers" in template.pre_processors` never succeeds.  This PR fixes this reporting.  As specified in the pre-commit config, I've also run the code through black.