### PR TITLE
feat(core): implement ProcessPoolExecutor for parallel processing (#259)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,30 +5,30 @@ repos:
     rev: v4.4.0
     hooks:
       - id: check-yaml
-        stages: [commit]
+        stages: [pre-commit]
       - id: check-added-large-files
         args: ['--maxkb=300']
         fail_fast: false
-        stages: [commit]
+        stages: [pre-commit]
       - id: pretty-format-json
         args: ['--autofix', '--no-sort-keys']
       - id: end-of-file-fixer
         exclude_types: ["csv", "json"]
-        stages: [commit]
+        stages: [pre-commit]
       - id: trailing-whitespace
-        stages: [commit]
+        stages: [pre-commit]
   - repo: https://github.com/pycqa/isort
     rev: 5.12.0
     hooks:
       - id: isort
         args: ["--profile", "black"]
-        stages: [commit]
+        stages: [pre-commit]
   - repo: https://github.com/psf/black
     rev: 23.3.0
     hooks:
       - id: black
         fail_fast: true
-        stages: [commit]
+        stages: [pre-commit]
   - repo: https://github.com/pycqa/flake8
     rev: 6.0.0
     hooks:
@@ -36,7 +36,7 @@ repos:
         args:
           - "--ignore=E501,W503,E203,E225,E713,E741,F541" # Line too long, Line break occurred before a binary operator, Whitespace before ':'
         fail_fast: true
-        stages: [commit]
+        stages: [pre-commit]
   - repo: local
     hooks:
       - id: pytest-on-commit
@@ -46,7 +46,7 @@ repos:
         pass_filenames: false
         always_run: true
         fail_fast: true
-        stages: [commit]
+        stages: [pre-commit]
   - repo: local
     hooks:
       - id: pytest-on-push
@@ -56,4 +56,4 @@ repos:
         pass_filenames: false
         always_run: true
         fail_fast: true
-        stages: [push]
+        stages: [pre-push]

--- a/src/entry.py
+++ b/src/entry.py
@@ -7,6 +7,7 @@
 
 """
 import os
+from concurrent.futures import ProcessPoolExecutor, as_completed
 from csv import QUOTE_NONNUMERIC
 from pathlib import Path
 from time import time
@@ -22,13 +23,14 @@ from src.constants.common import (
     TEMPLATE_FILENAME,
 )
 from src.defaults import CONFIG_DEFAULTS
-from src.evaluation import EvaluationConfig, evaluate_concatenated_response
+from src.evaluation import EvaluationConfig
 from src.logger import console, logger
 from src.template import Template
 from src.utils.file import Paths, setup_dirs_for_paths, setup_outputs_for_template
 from src.utils.image import ImageUtils
 from src.utils.interaction import InteractionUtils, Stats
-from src.utils.parsing import get_concatenated_response, open_config_with_defaults
+from src.utils.parallel import process_single_file_worker
+from src.utils.parsing import open_config_with_defaults
 
 # Load processors
 STATS = Stats()
@@ -212,129 +214,125 @@ def process_files(
     files_counter = 0
     STATS.files_not_moved = 0
 
-    for file_path in omr_files:
-        files_counter += 1
-        file_name = file_path.name
+    save_dir = outputs_namespace.paths.save_marked_dir
+    evaluation_dir = outputs_namespace.paths.evaluation_dir
 
-        in_omr = cv2.imread(str(file_path), cv2.IMREAD_GRAYSCALE)
-
-        logger.info("")
-        logger.info(
-            f"({files_counter}) Opening image: \t'{file_path}'\tResolution: {in_omr.shape}"
-        )
-
-        template.image_instance_ops.reset_all_save_img()
-
-        template.image_instance_ops.append_save_img(1, in_omr)
-
-        in_omr = template.image_instance_ops.apply_preprocessors(
-            file_path, in_omr, template
-        )
-
-        if in_omr is None:
-            # Error OMR case
-            new_file_path = outputs_namespace.paths.errors_dir.joinpath(file_name)
-            outputs_namespace.OUTPUT_SET.append(
-                [file_name] + outputs_namespace.empty_resp
+    futures = []
+    # If multiprocessing behaves badly, consider exposing max_workers configuraton.
+    with ProcessPoolExecutor(max_workers=os.cpu_count()) as executor:
+        for file_path in omr_files:
+            futures.append(
+                executor.submit(
+                    process_single_file_worker,
+                    file_path,
+                    template,
+                    tuning_config,
+                    evaluation_config,
+                    save_dir,
+                    evaluation_dir,
+                )
             )
-            if check_and_move(ERROR_CODES.NO_MARKER_ERR, file_path, new_file_path):
-                err_line = [
+
+        for future in as_completed(futures):
+            res = future.result()
+            files_counter += 1
+            file_name = res["file_name"]
+            file_path = res["file_path"]
+
+            logger.info("")
+            if res["status"] == "error":
+                new_file_path = outputs_namespace.paths.errors_dir.joinpath(file_name)
+                outputs_namespace.OUTPUT_SET.append(
+                    [file_name] + outputs_namespace.empty_resp
+                )
+                if check_and_move(res["error_code"], file_path, new_file_path):
+                    err_line = [
+                        file_name,
+                        file_path,
+                        new_file_path,
+                        "NA",
+                    ] + outputs_namespace.empty_resp
+                    pd.DataFrame(err_line, dtype=str).T.to_csv(
+                        outputs_namespace.files_obj["Errors"],
+                        mode="a",
+                        quoting=QUOTE_NONNUMERIC,
+                        header=False,
+                        index=False,
+                    )
+                continue
+
+            logger.info(
+                f"({files_counter}) Opened image: \t'{file_path}'\tResolution: {res.get('resolution', 'N/A')}"
+            )
+
+            file_id = res["file_id"]
+
+            if (
+                evaluation_config is None
+                or not evaluation_config.get_should_explain_scoring()
+            ):
+                logger.info(f"Read Response: \n{res['omr_response']}")
+
+            if evaluation_config is not None:
+                logger.info(
+                    f"(/{files_counter}) Graded with score: {round(res['score'], 2)}\t for file: '{file_id}'"
+                )
+            else:
+                logger.info(f"(/{files_counter}) Processed file: '{file_id}'")
+
+            if res.get("final_marked") is not None:
+                InteractionUtils.show(
+                    f"Final Marked Bubbles : '{file_id}'",
+                    ImageUtils.resize_util_h(
+                        res["final_marked"],
+                        int(tuning_config.dimensions.display_height * 1.3),
+                    ),
+                    1,
+                    1,
+                    config=tuning_config,
+                )
+
+            outputs_namespace.OUTPUT_SET.append([file_name] + res["resp_array"])
+
+            if (
+                res["multi_marked"] == 0
+                or not tuning_config.outputs.filter_out_multimarked_files
+            ):
+                STATS.files_not_moved += 1
+                new_file_path = save_dir.joinpath(file_id)
+                # Enter into Results sheet-
+                results_line = [
                     file_name,
                     file_path,
                     new_file_path,
-                    "NA",
-                ] + outputs_namespace.empty_resp
-                pd.DataFrame(err_line, dtype=str).T.to_csv(
-                    outputs_namespace.files_obj["Errors"],
+                    res["score"],
+                ] + res["resp_array"]
+                pd.DataFrame(results_line, dtype=str).T.to_csv(
+                    outputs_namespace.files_obj["Results"],
                     mode="a",
                     quoting=QUOTE_NONNUMERIC,
                     header=False,
                     index=False,
                 )
-            continue
-
-        # uniquify
-        file_id = str(file_name)
-        save_dir = outputs_namespace.paths.save_marked_dir
-        (
-            response_dict,
-            final_marked,
-            multi_marked,
-            _,
-        ) = template.image_instance_ops.read_omr_response(
-            template, image=in_omr, name=file_id, save_dir=save_dir
-        )
-
-        # TODO: move inner try catch here
-        # concatenate roll nos, set unmarked responses, etc
-        omr_response = get_concatenated_response(response_dict, template)
-
-        if (
-            evaluation_config is None
-            or not evaluation_config.get_should_explain_scoring()
-        ):
-            logger.info(f"Read Response: \n{omr_response}")
-
-        score = 0
-        if evaluation_config is not None:
-            score = evaluate_concatenated_response(
-                omr_response,
-                evaluation_config,
-                file_path,
-                outputs_namespace.paths.evaluation_dir,
-            )
-            logger.info(
-                f"(/{files_counter}) Graded with score: {round(score, 2)}\t for file: '{file_id}'"
-            )
-        else:
-            logger.info(f"(/{files_counter}) Processed file: '{file_id}'")
-
-        if tuning_config.outputs.show_image_level >= 2:
-            InteractionUtils.show(
-                f"Final Marked Bubbles : '{file_id}'",
-                ImageUtils.resize_util_h(
-                    final_marked, int(tuning_config.dimensions.display_height * 1.3)
-                ),
-                1,
-                1,
-                config=tuning_config,
-            )
-
-        resp_array = []
-        for k in template.output_columns:
-            resp_array.append(omr_response[k])
-
-        outputs_namespace.OUTPUT_SET.append([file_name] + resp_array)
-
-        if multi_marked == 0 or not tuning_config.outputs.filter_out_multimarked_files:
-            STATS.files_not_moved += 1
-            new_file_path = save_dir.joinpath(file_id)
-            # Enter into Results sheet-
-            results_line = [file_name, file_path, new_file_path, score] + resp_array
-            # Write/Append to results_line file(opened in append mode)
-            pd.DataFrame(results_line, dtype=str).T.to_csv(
-                outputs_namespace.files_obj["Results"],
-                mode="a",
-                quoting=QUOTE_NONNUMERIC,
-                header=False,
-                index=False,
-            )
-        else:
-            # multi_marked file
-            logger.info(f"[{files_counter}] Found multi-marked file: '{file_id}'")
-            new_file_path = outputs_namespace.paths.multi_marked_dir.joinpath(file_name)
-            if check_and_move(ERROR_CODES.MULTI_BUBBLE_WARN, file_path, new_file_path):
-                mm_line = [file_name, file_path, new_file_path, "NA"] + resp_array
-                pd.DataFrame(mm_line, dtype=str).T.to_csv(
-                    outputs_namespace.files_obj["MultiMarked"],
-                    mode="a",
-                    quoting=QUOTE_NONNUMERIC,
-                    header=False,
-                    index=False,
+            else:
+                # multi_marked file
+                logger.info(f"[{files_counter}] Found multi-marked file: '{file_id}'")
+                new_file_path = outputs_namespace.paths.multi_marked_dir.joinpath(
+                    file_name
                 )
-            # else:
-            #     TODO:  Add appropriate record handling here
-            #     pass
+                if check_and_move(
+                    ERROR_CODES.MULTI_BUBBLE_WARN, file_path, new_file_path
+                ):
+                    mm_line = [file_name, file_path, new_file_path, "NA"] + res[
+                        "resp_array"
+                    ]
+                    pd.DataFrame(mm_line, dtype=str).T.to_csv(
+                        outputs_namespace.files_obj["MultiMarked"],
+                        mode="a",
+                        quoting=QUOTE_NONNUMERIC,
+                        header=False,
+                        index=False,
+                    )
 
     print_stats(start_time, files_counter, tuning_config)
 

--- a/src/utils/parallel.py
+++ b/src/utils/parallel.py
@@ -1,0 +1,75 @@
+import cv2
+
+from src.constants.common import ERROR_CODES
+from src.evaluation import evaluate_concatenated_response
+from src.utils.parsing import get_concatenated_response
+
+
+def process_single_file_worker(
+    file_path, template, tuning_config, evaluation_config, save_dir, evaluation_dir
+):
+    """
+    Worker function for processing a single OMR file in parallel.
+    """
+    file_name = file_path.name
+    file_id = str(file_name)
+
+    in_omr = cv2.imread(str(file_path), cv2.IMREAD_GRAYSCALE)
+    resolution = in_omr.shape
+
+    template.image_instance_ops.reset_all_save_img()
+    template.image_instance_ops.append_save_img(1, in_omr)
+
+    in_omr = template.image_instance_ops.apply_preprocessors(
+        file_path, in_omr, template
+    )
+
+    if in_omr is None:
+        return {
+            "status": "error",
+            "file_name": file_name,
+            "file_path": file_path,
+            "error_code": ERROR_CODES.NO_MARKER_ERR,
+        }
+
+    (
+        response_dict,
+        final_marked,
+        multi_marked,
+        _,
+    ) = template.image_instance_ops.read_omr_response(
+        template, image=in_omr, name=file_id, save_dir=save_dir
+    )
+
+    omr_response = get_concatenated_response(response_dict, template)
+
+    score = 0
+    if evaluation_config is not None:
+        score = evaluate_concatenated_response(
+            omr_response,
+            evaluation_config,
+            file_path,
+            evaluation_dir,
+        )
+
+    resp_array = []
+    for k in template.output_columns:
+        resp_array.append(omr_response[k])
+
+    # Return final_marked only if it's needed for visualization to save IPC overhead
+    return_final_marked = None
+    if tuning_config.outputs.show_image_level >= 2:
+        return_final_marked = final_marked
+
+    return {
+        "status": "success",
+        "file_name": file_name,
+        "file_path": file_path,
+        "file_id": file_id,
+        "score": score,
+        "resp_array": resp_array,
+        "multi_marked": multi_marked,
+        "omr_response": omr_response,
+        "final_marked": return_final_marked,
+        "resolution": resolution,
+    }


### PR DESCRIPTION
Here is a professional PR description you can copy and paste directly into GitHub:

***

**Fixes #259**

### Description
This Pull Request introduces parallel processing to significantly speed up OMR evaluation across large datasets. By utilizing `ProcessPoolExecutor`, we can now distribute the heavy OpenCV image processing tasks concurrently across multiple CPU cores.

#### Key Changes:
- **Created a standalone worker function**: Extracted the core image evaluation logic (from the sequential `for file_path in omr_files` loop) into a thread-safe [process_single_file_worker](cci:1://file:///c:/Users/bages/OMRChecker/src/utils/parallel.py:7:0-74:5) inside a new [src/utils/parallel.py](cci:7://file:///c:/Users/bages/OMRChecker/src/utils/parallel.py:0:0-0:0) file.
- **Implemented `ProcessPoolExecutor`**: Modified [src/entry.py](cci:7://file:///c:/Users/bages/OMRChecker/src/entry.py:0:0-0:0) to dispatch file evaluations concurrently utilizing `os.cpu_count()`.
- **Safe State Updates**: Passed the processed results securely back to the main thread via a return dictionary to safely track files in the `STATS` counter and append to `OUTPUT_SET` / CSV DataFrames without race conditions.
- **Minimized IPC Overhead**: Prevented expensive `cv2` image objects from traveling between processes unless interactive visuals (`show_image_level >= 2`) are enabled.

### Testing Done:
- Successfully processed the existing OMR templates in `samples/sample1`, `samples/answer-key/using-csv`, and `samples/answer-key/weighted-answers/images` with perfect visual and mathematical grading accuracy compared to the sequential output.

***
