### PR TITLE
fix(validation): show full nested key paths in schema errors

### DIFF
--- a/src/tests/test_template_validations.py
+++ b/src/tests/test_template_validations.py
@@ -1,12 +1,14 @@
 import os
 from pathlib import Path
 
+from src.schemas import SCHEMA_VALIDATORS
 from src.tests.test_samples.sample1.boilerplate import TEMPLATE_BOILERPLATE
 from src.tests.utils import (
     generate_write_jsons_and_run,
     run_entry_point,
     setup_mocker_patches,
 )
+from src.utils.validations import parse_validation_error
 
 FROZEN_TIMESTAMP = "1970-01-01"
 CURRENT_DIR = Path("src/tests")
@@ -157,3 +159,36 @@ def test_safe_missing_label_columns(mocker):
 
     exception = write_jsons_and_run(mocker, modify_template=modify_template)
     assert str(exception) == "No Error"
+
+
+def test_parse_validation_error_for_nested_field_block_key():
+    template = {
+        **TEMPLATE_BOILERPLATE,
+        "fieldBlocks": {
+            "MCQ_Block_1": {
+                **TEMPLATE_BOILERPLATE["fieldBlocks"]["MCQ_Block_1"],
+                "fieldType": "X",
+            }
+        },
+    }
+
+    error = next(SCHEMA_VALIDATORS["template"].iter_errors(template))
+    key, validator, _msg = parse_validation_error(error)
+
+    assert key == "fieldBlocks.MCQ_Block_1.fieldType"
+    assert validator == "enum"
+
+
+def test_parse_validation_error_for_nested_preprocessor_key():
+    template = {
+        **TEMPLATE_BOILERPLATE,
+        "preProcessors": [
+            {"name": "CropPage", "options": {"morphKernel": [10]}},
+        ],
+    }
+
+    error = next(SCHEMA_VALIDATORS["template"].iter_errors(template))
+    key, validator, _msg = parse_validation_error(error)
+
+    assert key == "preProcessors[0].options.morphKernel"
+    assert validator == "minItems"

--- a/src/utils/validations.py
+++ b/src/utils/validations.py
@@ -62,10 +62,16 @@ def validate_template_json(json_data, template_path):
             key, validator, msg = parse_validation_error(error)
 
             # Print preProcessor name in case of options error
-            if key == "preProcessors":
+            if (
+                len(error.path) > 2
+                and error.path[0] == "preProcessors"
+                and isinstance(error.path[1], int)
+            ):
                 preProcessorName = json_data["preProcessors"][error.path[1]]["name"]
                 preProcessorKey = error.path[2]
-                table.add_row(f"{key}.{preProcessorName}.{preProcessorKey}", msg)
+                table.add_row(
+                    f"preProcessors.{preProcessorName}.{preProcessorKey}", msg
+                )
             elif validator == "required":
                 requiredProperty = re.findall(r"'(.*?)'", msg)[0]
                 table.add_row(
@@ -108,8 +114,22 @@ def validate_config_json(json_data, config_path):
 
 
 def parse_validation_error(error):
-    return (
-        (error.path[0] if len(error.path) > 0 else "$root"),
-        error.validator,
-        error.message,
-    )
+    return (format_json_path(error.path), error.validator, error.message)
+
+
+def format_json_path(path):
+    path_tokens = list(path)
+
+    if len(path_tokens) == 0:
+        return "$root"
+
+    formatted_path = []
+    for path_token in path_tokens:
+        if isinstance(path_token, int):
+            formatted_path.append(f"[{path_token}]")
+        elif len(formatted_path) == 0:
+            formatted_path.append(str(path_token))
+        else:
+            formatted_path.append(f".{path_token}")
+
+    return "".join(formatted_path)

--- a/src/utils/validations.py
+++ b/src/utils/validations.py
@@ -67,7 +67,18 @@ def validate_template_json(json_data, template_path):
                 and error.path[0] == "preProcessors"
                 and isinstance(error.path[1], int)
             ):
-                preProcessorName = json_data["preProcessors"][error.path[1]]["name"]
+                preProcessorIndex = error.path[1]
+                preProcessors = json_data.get("preProcessors", [])
+                preProcessorName = f"index_{preProcessorIndex}"
+
+                if (
+                    isinstance(preProcessors, list)
+                    and 0 <= preProcessorIndex < len(preProcessors)
+                    and isinstance(preProcessors[preProcessorIndex], dict)
+                ):
+                    preProcessorName = preProcessors[preProcessorIndex].get(
+                        "name", preProcessorName
+                    )
                 preProcessorKey = error.path[2]
                 table.add_row(
                     f"preProcessors.{preProcessorName}.{preProcessorKey}", msg


### PR DESCRIPTION
## Summary

Improve schema validation error reporting by showing full nested key paths instead of only the top-level key.

## Changes

- format full nested jsonschema paths like `fieldBlocks.MCQ_Block_1.fieldType`
- preserve friendly preprocessor-specific output for template validation errors
- add focused regression tests for nested `fieldBlocks` and `preProcessors` schema errors

## Why

This is a small first step for #65 to make template schema validation messages more useful without changing validation behavior.

Previously, nested schema errors could get reported with only a broad top-level key like `fieldBlocks` or `preProcessors`. With this change, users can see the exact nested location of the invalid value.

## Testing

- added regression tests for nested schema error path formatting
- manually verified returned paths for:
  - `fieldBlocks.MCQ_Block_1.fieldType`
  - `preProcessors[0].options.morphKernel`

## Notes

- this PR does not add stricter inner `fieldBlocks` validation yet
- that follow-up can be done in a separate PR to keep this change small and easy to review

Partially fixes #65
