### PR TITLE
feat(CropPage): allow skipping crop if page boundary not found (Fixes #215)

### DIFF
--- a/src/processors/CropPage.py
+++ b/src/processors/CropPage.py
@@ -62,17 +62,27 @@ class CropPage(ImagePreprocessor):
         self.morph_kernel = tuple(
             int(x) for x in cropping_ops.get("morphKernel", [10, 10])
         )
+        self.should_fail_if_page_not_found = cropping_ops.get(
+            "shouldFailIfPageNotFound", True
+        )
 
     def apply_filter(self, image, file_path):
+        original_image = image.copy()
         image = normalize(cv2.GaussianBlur(image, DEFAULT_GAUSSIAN_BLUR_KERNEL, 0))
 
         # Resize should be done with another preprocessor is needed
         sheet = self.find_page(image, file_path)
         if len(sheet) == 0:
-            logger.error(
-                f"\tError: Paper boundary not found for: '{file_path}'\nHave you accidentally included CropPage preprocessor?"
-            )
-            return None
+            if self.should_fail_if_page_not_found:
+                logger.error(
+                    f"\tError: Paper boundary not found for: '{file_path}'\nHave you accidentally included CropPage preprocessor?"
+                )
+                return None
+            else:
+                logger.warning(
+                    f"\tWarning: Paper boundary not found for: '{file_path}', skipping crop."
+                )
+                return original_image
 
         logger.info(f"Found page corners: \t {sheet.tolist()}")
 

--- a/src/schemas/template_schema.py
+++ b/src/schemas/template_schema.py
@@ -173,7 +173,8 @@ TEMPLATE_SCHEMA = {
                                     "type": "object",
                                     "additionalProperties": False,
                                     "properties": {
-                                        "morphKernel": two_positive_integers
+                                        "morphKernel": two_positive_integers,
+                                        "shouldFailIfPageNotFound": {"type": "boolean"},
                                     },
                                 }
                             }

--- a/src/tests/test_samples/sample1/boilerplate.py
+++ b/src/tests/test_samples/sample1/boilerplate.py
@@ -1,7 +1,12 @@
 TEMPLATE_BOILERPLATE = {
     "pageDimensions": [300, 400],
     "bubbleDimensions": [25, 25],
-    "preProcessors": [{"name": "CropPage", "options": {"morphKernel": [10, 10]}}],
+    "preProcessors": [
+        {
+            "name": "CropPage",
+            "options": {"morphKernel": [10, 10], "shouldFailIfPageNotFound": False},
+        }
+    ],
     "fieldBlocks": {
         "MCQ_Block_1": {
             "fieldType": "QTYPE_MCQ5",


### PR DESCRIPTION
Resolves #215. Added `shouldFailIfPageNotFound` to skip crop if the page is not found. Includes pre-commit formatting fixes.