### PR TITLE
fix: mock remaining OpenCV GUI calls in tests to prevent guiReceiver error

### DIFF
--- a/src/tests/utils.py
+++ b/src/tests/utils.py
@@ -19,6 +19,15 @@ def setup_mocker_patches(mocker):
     mock_wait_key = mocker.patch("cv2.waitKey")
     mock_wait_key.return_value = ord("q")
 
+    mock_named_window = mocker.patch("cv2.namedWindow")
+    mock_named_window.return_value = None
+
+    mock_move_window = mocker.patch("cv2.moveWindow")
+    mock_move_window.return_value = None
+
+    mock_get_window_property = mocker.patch("cv2.getWindowProperty")
+    mock_get_window_property.return_value = 1
+
 
 def run_entry_point(input_path, output_dir):
     args = {


### PR DESCRIPTION
## Problem
When running `pytest` or `pre-commit` hooks in headless environments (e.g., CI runners, containers, or environments without an active display server), the test suite fails with:


## Root Cause
`InteractionUtils.show()` and `is_window_available()` in `src/utils/interaction.py` invoke `cv2.namedWindow()`, `cv2.moveWindow()`, and `cv2.getWindowProperty()`. Previously, `setup_mocker_patches()` in `src/tests/utils.py` only mocked `cv2.imshow`, `cv2.destroyAllWindows`, and `cv2.waitKey`. The three unmocked OpenCV GUI functions attempted real GUI window operations during testing, which fail in headless environments without a display backend.

## Fix
Updated `setup_mocker_patches(mocker)` in `src/tests/utils.py` to add mocks for the remaining OpenCV GUI calls:
- `cv2.namedWindow` -> returns `None`
- `cv2.moveWindow` -> returns `None`
- `cv2.getWindowProperty` -> returns `1` (simulates window visibility)

No production code in `src/utils/interaction.py` was altered, preserving actual display runtime behavior for end users.

## Testing Notes
- Verified locally via `pytest` and `pre-commit` that `cv2.error: NULL guiReceiver (please create a window)` is completely eliminated.
- *Note:* Snapshot test failures when running locally on Windows are due to pre-existing OS-specific path separator differences (`\` vs `/`) and are unrelated to this OpenCV GUI mocking fix.

Fixes #230

