### PR TITLE
fix: resume copying error/multi-marked files to their output directories

### DIFF
--- a/src/entry.py
+++ b/src/entry.py
@@ -7,11 +7,11 @@
 
 """
 import os
+import shutil
 from csv import QUOTE_NONNUMERIC
 from pathlib import Path
 from time import time
 
-import cv2
 import pandas as pd
 from rich.table import Table
 
@@ -183,7 +183,6 @@ def process_dir(
             tuning_config,
             evaluation_config,
         )
-
 
 
 def show_template_layouts(omr_files, template, tuning_config, outputs_namespace):
@@ -386,8 +385,29 @@ def process_files(
 
 
 def check_and_move(error_code, file_path, filepath2):
-    # TODO: fix file movement into error/multimarked/invalid etc again
-    STATS.files_not_moved += 1
+    """Copy a source file (error/multi-marked) into its output directory.
+
+    The source file is copied rather than moved so that committed sample
+    inputs and repeatable test runs are not destroyed. On success the
+    source remains in place while a copy is created at the destination.
+    """
+    if not file_path.exists():
+        logger.warning(f"Source file '{file_path}' does not exist, cannot move it")
+        return False
+    if filepath2.exists():
+        logger.warning(
+            f"Destination file '{filepath2}' already exists, not overwriting"
+        )
+        return False
+    try:
+        shutil.copy2(file_path, filepath2)
+    except OSError as error:
+        logger.error(
+            f"Failed to copy file '{file_path}' to '{filepath2}' "
+            f"for error code '{error_code}': {error}"
+        )
+        return False
+    STATS.files_moved += 1
     return True
 
 

--- a/src/tests/test_check_and_move.py
+++ b/src/tests/test_check_and_move.py
@@ -1,0 +1,78 @@
+import pytest
+
+from src.constants.common import ERROR_CODES
+from src.entry import STATS, check_and_move
+
+
+@pytest.fixture(autouse=True)
+def reset_stats():
+    files_moved_before = STATS.files_moved
+    files_not_moved_before = STATS.files_not_moved
+    STATS.files_moved = 0
+    STATS.files_not_moved = 0
+    yield
+    STATS.files_moved = files_moved_before
+    STATS.files_not_moved = files_not_moved_before
+
+
+def test_check_and_move_copies_file(tmp_path):
+    source = tmp_path / "input.png"
+    destination = tmp_path / "Manual" / "ErrorFiles" / "input.png"
+    destination.parent.mkdir(parents=True)
+
+    source.write_bytes(b"test")
+
+    result = check_and_move(ERROR_CODES.NO_MARKER_ERR, source, destination)
+
+    assert result is True
+    assert source.exists()
+    assert source.read_bytes() == b"test"
+    assert destination.exists()
+    assert destination.read_bytes() == b"test"
+    assert STATS.files_moved == 1
+    assert STATS.files_not_moved == 0
+
+
+def test_check_and_move_false_when_source_missing(tmp_path):
+    source = tmp_path / "input.png"
+    destination = tmp_path / "Manual" / "ErrorFiles" / "input.png"
+    destination.parent.mkdir(parents=True)
+
+    result = check_and_move(ERROR_CODES.NO_MARKER_ERR, source, destination)
+
+    assert result is False
+    assert not destination.exists()
+    assert STATS.files_moved == 0
+    assert STATS.files_not_moved == 0
+
+
+def test_check_and_move_false_when_destination_exists(tmp_path):
+    source = tmp_path / "input.png"
+    destination = tmp_path / "Manual" / "ErrorFiles" / "input.png"
+    destination.parent.mkdir(parents=True)
+
+    source.write_bytes(b"source")
+    destination.write_bytes(b"existing")
+
+    result = check_and_move(ERROR_CODES.NO_MARKER_ERR, source, destination)
+
+    assert result is False
+    assert source.exists()
+    assert destination.read_bytes() == b"existing"
+    assert STATS.files_moved == 0
+    assert STATS.files_not_moved == 0
+
+
+def test_check_and_move_false_when_destination_dir_missing(tmp_path):
+    source = tmp_path / "input.png"
+    destination = tmp_path / "Missing" / "input.png"
+
+    source.write_bytes(b"test")
+
+    result = check_and_move(ERROR_CODES.NO_MARKER_ERR, source, destination)
+
+    assert result is False
+    assert source.exists()
+    assert not destination.exists()
+    assert STATS.files_moved == 0
+    assert STATS.files_not_moved == 0


### PR DESCRIPTION
## Summary

Fixes #299

`check_and_move()` currently only increments `STATS.files_not_moved` and returns `True` without ever creating the destination file. As a result:

- error and multi-marked files are never placed in their output directories;
- the `output_path` recorded in `ErrorFiles.csv` / `MultiMarkedFiles.csv` points at a file that does not exist;
- `STATS.files_moved` is never incremented, so the summary always reports `0` moved files.

This PR restores the intended behavior so a successful call creates the destination file, returns `True`, and increments `STATS.files_moved`.

## Changes

- `src/entry.py`
  - `check_and_move()` now copies the source file to the destination with `shutil.copy2` (errors are logged and `False` is returned on failure).
  - Returns `False` (without overwriting) if the source does not exist or the destination already exists.
  - On success returns `True` and increments `STATS.files_moved` (`STATS.files_not_moved` no longer counts these files).
  - Removed the now-unused `cv2` import and an extra blank line (pre-existing lint issues in this file).
- `src/tests/test_check_and_move.py` (new)
  - Unit tests covering: successful copy (+stats), source missing, destination already exists (no overwrite), and missing destination directory.

## Semantics note (move vs copy)

Issue #299 asks whether error/multi-marked files should be **moved** or **copied**. I chose **copy** (`shutil.copy2`) rather than `os.rename`/move because several committed sample inputs (e.g. `samples/sample1/single_image_error.pdf`) are the *source* files for these files — moving them would destroy the committed sample assets and make the integration tests non-reproducible across runs and CI hosts.

With copy semantics the source stays in place, a real destination file is produced, and the recorded `output_path` is valid. Happy to switch to move semantics if the maintainers prefer that.

## Verification

- `flake8` (repo config) passes on both changed files.
- New unit tests pass:
  - `pytest src/tests/test_check_and_move.py` -> 4 passed