### PR TITLE
feat: allow CropPage to skip cropping when page boundary is not found

### DIFF
--- a/src/processors/CropPage.py
+++ b/src/processors/CropPage.py
@@ -62,6 +62,9 @@ class CropPage(ImagePreprocessor):
         self.morph_kernel = tuple(
             int(x) for x in cropping_ops.get("morphKernel", [10, 10])
         )
+        self.should_fail_if_page_not_found = bool(
+            cropping_ops.get("shouldFailIfPageNotFound", True)
+        )
 
     def apply_filter(self, image, file_path):
         image = normalize(cv2.GaussianBlur(image, DEFAULT_GAUSSIAN_BLUR_KERNEL, 0))
@@ -69,6 +72,12 @@ class CropPage(ImagePreprocessor):
         # Resize should be done with another preprocessor is needed
         sheet = self.find_page(image, file_path)
         if len(sheet) == 0:
+            if not self.should_fail_if_page_not_found:
+                logger.warning(
+                    f"\tPaper boundary not found for: '{file_path}'. "
+                    "Continuing without cropping."
+                )
+                return image
             logger.error(
                 f"\tError: Paper boundary not found for: '{file_path}'\nHave you accidentally included CropPage preprocessor?"
             )

--- a/src/schemas/template_schema.py
+++ b/src/schemas/template_schema.py
@@ -173,7 +173,8 @@ TEMPLATE_SCHEMA = {
                                     "type": "object",
                                     "additionalProperties": False,
                                     "properties": {
-                                        "morphKernel": two_positive_integers
+                                        "morphKernel": two_positive_integers,
+                                        "shouldFailIfPageNotFound": {"type": "boolean"},
                                     },
                                 }
                             }

--- a/src/tests/test_crop_page.py
+++ b/src/tests/test_crop_page.py
@@ -1,0 +1,48 @@
+import numpy as np
+
+from dotmap import DotMap
+
+from src.processors.manager import PROCESSOR_MANAGER
+
+CropPage = PROCESSOR_MANAGER.processors["CropPage"]
+
+
+def make_croppage(should_fail_if_page_not_found=True):
+    fake_ops = type("FakeImageInstanceOps", (), {})()
+    fake_ops.tuning_config = DotMap(outputs=DotMap(show_image_level=0))
+    options = {"shouldFailIfPageNotFound": should_fail_if_page_not_found}
+    return CropPage(
+        options=options,
+        relative_dir=None,
+        image_instance_ops=fake_ops,
+    )
+
+
+def random_image(shape=(100, 100, 3)):
+    return np.random.randint(0, 256, shape, dtype=np.uint8)
+
+
+def test_crop_page_fails_when_page_not_found_by_default():
+    croppage = make_croppage()
+    image = random_image()
+    # Area is below MIN_PAGE_AREA_THRESHOLD, so no page can be detected.
+    assert croppage.apply_filter(image, "test.png") is None
+
+
+def test_crop_page_returns_image_when_skip_requested():
+    croppage = make_croppage(should_fail_if_page_not_found=False)
+    image = random_image()
+    output = croppage.apply_filter(image, "test.png")
+    assert output is not None
+    assert output.shape == image.shape
+
+
+def test_should_fail_if_page_not_found_defaults_to_true():
+    fake_ops = type("FakeImageInstanceOps", (), {})()
+    fake_ops.tuning_config = DotMap(outputs=DotMap(show_image_level=0))
+    croppage = CropPage(
+        options={},
+        relative_dir=None,
+        image_instance_ops=fake_ops,
+    )
+    assert croppage.should_fail_if_page_not_found is True


### PR DESCRIPTION
## Summary

Fixes #215

When `CropPage` is combined with other pre-processors (e.g. `CropOnMarkers`), a scan where the paper boundary is not visible currently gets rejected even though the markers can still be detected successfully.

This PR adds a new `shouldFailIfPageNotFound` option to `CropPage` (default `true`). When set to `false`, `CropPage` logs a warning and returns the (preprocessed) input image without cropping, so processing can continue downstream instead of failing.

## Changes

- `src/processors/CropPage.py`
  - Read `shouldFailIfPageNotFound` from the processor `options` (defaults to `true`, preserving current behavior).
  - In `apply_filter`, when no page boundary is found: return the input image untouched if `shouldFailIfPageNotFound` is `false`; otherwise keep the existing error behavior.
- `src/schemas/template_schema.py`
  - Allow the new boolean option in the `CropPage` preprocessor options schema, e.g.:

```json
{
  "name": "CropPage",
  "options": {
    "shouldFailIfPageNotFound": false
  }
}
```

- `src/tests/test_crop_page.py` (new)
  - Unit tests covering the default fail behavior and the skip-crop behavior (using a synthetic image below `MIN_PAGE_AREA_THRESHOLD` so no page can be detected deterministically).

## Verification

- `flake8` and `black` (repo config) pass on all changed files.
- `pytest src/tests/test_crop_page.py` -> 3 passed.

## Notes

- Default behavior is unchanged (`shouldFailIfPageNotFound` defaults to `true`), so no existing templates or snapshots are affected.
- The flag lives in the preprocessor `options` (alongside `morphKernel`); happy to move it to `config.json` if the maintainers prefer a global setting.